### PR TITLE
Add ? to noncapturing group for querystring handling

### DIFF
--- a/scripts/expand.coffee
+++ b/scripts/expand.coffee
@@ -9,7 +9,7 @@
 #   uiureo
 
 module.exports = (robot) ->
-  GYAZO_REGEXP = /(https?:\/\/(?:[^\.]+\.)?gyazo.com\/[0-9a-f]{32})\/?(?:\s|$)/gi
+  GYAZO_REGEXP = /(https?:\/\/(?:[^\.]+\.)?gyazo.com\/[0-9a-f]{32})\/?(?:\s|\?|$)/gi
 
   extractGyazoUrls = (text) ->
     urls = []


### PR DESCRIPTION
Gyazo has started adding a ?token=[:id] query string recently, which this script didn't handle appropriately before. This update should fix that. 